### PR TITLE
add circle deploy to github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
             git config user.name "ci-build"
       - add_ssh_keys:
           fingerprints:
-            - ####  CHANGE ME  #####
+            - "8d:43:a0:40:1a:ec:b3:24:b8:79:79:15:b9:c7:be:ef"
       - run: 
           name: list files pushed
           command: ls public


### PR DESCRIPTION
This adds the correct deployment key fingerprint for CircleCI. I set up circle integration within Github and on Circle and so now this is ready for building once we merge `develop` into `master`. 

cc @adisadit 